### PR TITLE
Avoid search when empty text

### DIFF
--- a/lib/google_places_flutter.dart
+++ b/lib/google_places_flutter.dart
@@ -182,7 +182,9 @@ class _GooglePlaceAutoCompleteTextFieldState
   }
 
   textChanged(String text) async {
-    getLocation(text);
+    if (text != ''){
+      getLocation(text);
+    }
   }
 
   OverlayEntry? _createOverlayEntry() {


### PR DESCRIPTION
Background: This MR to avoid search to api when empty text

Reproduce: Fast typing on search address text and backspace before bounce reached.

Why: When empty text will show snackbar `The Provided API key is invalid`. You can show my video


https://github.com/Shrutimahajan/Google-AutoComplete-TextField-Flutter/assets/31463340/d01569d1-bbd1-41fb-ae7a-6fbd1705c069

