### PR TITLE
Add configurable keyboardType parameter with streetAddress as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,4 +47,9 @@
 
 * Added Near By Search and Some Bug fixes and improvements
 
+## Unreleased
+
+* Added `keyboardType` parameter to customize the keyboard input type (defaults to `TextInputType.streetAddress` for better address input experience)
+* Made keyboard type configurable while maintaining backward compatibility
+
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ dependencies:
          containerHorizontalPadding: 10,
          // place type
         placeType: PlaceType.geocode,
+        // keyboard type (defaults to TextInputType.streetAddress)
+        keyboardType: TextInputType.text, // optional - defaults to streetAddress for better address input
          
          
         

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -92,6 +92,9 @@ class _MyHomePageState extends State<MyHomePage> {
         },
         seperatedBuilder: Divider(),
         containerHorizontalPadding: 10,
+        
+        // Optional: specify keyboard type (defaults to TextInputType.streetAddress)
+        // keyboardType: TextInputType.text,
 
 
         // OPTIONAL// If you want to customize list view item builder

--- a/lib/google_places_flutter.dart
+++ b/lib/google_places_flutter.dart
@@ -35,6 +35,7 @@ class GooglePlaceAutoCompleteTextField extends StatefulWidget {
   String? language;
   TextInputAction? textInputAction;
   final VoidCallback? formSubmitCallback;
+  TextInputType? keyboardType;
 
   final String? Function(String?, BuildContext)? validator;
 
@@ -70,6 +71,7 @@ class GooglePlaceAutoCompleteTextField extends StatefulWidget {
       this.radius,
       this.formSubmitCallback,
       this.textInputAction,
+      this.keyboardType,
       this.clearData});
 
   @override
@@ -116,6 +118,7 @@ class _GooglePlaceAutoCompleteTextFieldState
                 style: widget.textStyle,
                 controller: widget.textEditingController,
                 focusNode: widget.focusNode ?? FocusNode(),
+                keyboardType: widget.keyboardType ?? TextInputType.streetAddress,
                 textInputAction: widget.textInputAction ?? TextInputAction.done,
                 onFieldSubmitted: (value) {
                   if(widget.formSubmitCallback!=null){


### PR DESCRIPTION
## Summary
This PR adds a new optional `keyboardType` parameter to the `GooglePlaceAutoCompleteTextField` widget, with `TextInputType.streetAddress` as the default value. This enhancement improves the user experience by providing a more appropriate keyboard layout for address input.

## Changes
- ✨ Added optional `keyboardType` parameter to `GooglePlaceAutoCompleteTextField`
- 🎯 Set `TextInputType.streetAddress` as the default keyboard type for better address input experience
- 📝 Updated README.md with documentation for the new parameter
- 📝 Updated example code to demonstrate usage
- 📝 Updated CHANGELOG.md to document the enhancement
- ✅ Maintains full backward compatibility

## Motivation
When users are entering addresses in the autocomplete field, having the appropriate keyboard type (`streetAddress`) provides a better user experience with optimized keyboard layouts on both iOS and Android. This is especially helpful as it:
- Shows relevant suggestions on mobile keyboards
- Provides better autocorrect for address-related terms
- Improves the overall input experience for location searches

## Usage Example
```dart
// Use default streetAddress keyboard type (recommended for address input)
GooglePlaceAutoCompleteTextField(
  textEditingController: controller,
  googleAPIKey: "YOUR_API_KEY",
  // ... other parameters
)

// Or customize keyboard type if needed
GooglePlaceAutoCompleteTextField(
  textEditingController: controller,
  googleAPIKey: "YOUR_API_KEY",
  keyboardType: TextInputType.text, // Override default
  // ... other parameters
)
```

## Testing
- ✅ The change maintains backward compatibility - existing implementations will continue to work without modification
- ✅ The default `TextInputType.streetAddress` provides an improved experience for address input
- ✅ Developers can still override the keyboard type if they have specific requirements

## Breaking Changes
None - This is a backward-compatible enhancement.

## Checklist
- [x] Code follows the existing style and conventions
- [x] Documentation has been updated
- [x] Example has been updated
- [x] CHANGELOG.md has been updated
- [x] The change is backward compatible