### PR TITLE
feat: add support for Google Places API v1 with useNewApi flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ dependencies:
 ```
     GooglePlaceAutoCompleteTextField(
         textEditingController: controller,
+        // use Places API (New)
+        useNewApi: true,
         googleAPIKey: "YOUR_GOOGLE_API_KEY",
         inputDecoration: InputDecoration()
         debounceTime: 800 // default 600 ms,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,6 +72,8 @@ class _MyHomePageState extends State<MyHomePage> {
       padding: EdgeInsets.symmetric(horizontal: 20),
       child: GooglePlaceAutoCompleteTextField(
         textEditingController: controller,
+        // use Places API (New)
+        useNewApi: true,
         googleAPIKey:"YOUR_GOOGLE_API_KEY",
         inputDecoration: InputDecoration(
           hintText: "Search your location",

--- a/lib/DioErrorHandler.dart
+++ b/lib/DioErrorHandler.dart
@@ -35,7 +35,9 @@ class DioErrorHandler {
 
           if (dioError.response?.data['message'] != null) {
             errorResponse.message = dioError.response?.data['message'];
-          } else {
+          } else if (dioError.response?.data['error'] != null) {
+            errorResponse.message = dioError.response?.data['error']['message'];
+          }  else {
             if ((dioError.response?.statusMessage ?? "").isNotEmpty)
               errorResponse.message = dioError.response?.statusMessage;
             else

--- a/lib/model/new_place_details.dart
+++ b/lib/model/new_place_details.dart
@@ -1,0 +1,67 @@
+class NewPlaceDetails {
+  String? id;
+  Location? location;
+  DisplayName? displayName;
+
+  NewPlaceDetails({this.id, this.location, this.displayName});
+
+  NewPlaceDetails.fromJson(Map<String, dynamic> json) {
+    id = json['id'];
+    location = json['location'] != null 
+        ? Location.fromJson(json['location']) 
+        : null;
+    displayName = json['displayName'] != null 
+        ? DisplayName.fromJson(json['displayName']) 
+        : null;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['id'] = id;
+    if (location != null) {
+      data['location'] = location!.toJson();
+    }
+    if (displayName != null) {
+      data['displayName'] = displayName!.toJson();
+    }
+    return data;
+  }
+}
+
+class Location {
+  double? latitude;
+  double? longitude;
+
+  Location({this.latitude, this.longitude});
+
+  Location.fromJson(Map<String, dynamic> json) {
+    latitude = json['latitude']?.toDouble();
+    longitude = json['longitude']?.toDouble();
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['latitude'] = latitude;
+    data['longitude'] = longitude;
+    return data;
+  }
+}
+
+class DisplayName {
+  String? text;
+  String? languageCode;
+
+  DisplayName({this.text, this.languageCode});
+
+  DisplayName.fromJson(Map<String, dynamic> json) {
+    text = json['text'];
+    languageCode = json['languageCode'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['text'] = text;
+    data['languageCode'] = languageCode;
+    return data;
+  }
+}

--- a/lib/model/new_prediction.dart
+++ b/lib/model/new_prediction.dart
@@ -1,0 +1,151 @@
+class NewPlacesAutocompleteResponse {
+  List<Suggestion>? suggestions;
+
+  NewPlacesAutocompleteResponse({this.suggestions});
+
+  NewPlacesAutocompleteResponse.fromJson(Map<String, dynamic> json) {
+    if (json['suggestions'] != null) {
+      suggestions = [];
+      json['suggestions'].forEach((v) {
+        suggestions!.add(Suggestion.fromJson(v));
+      });
+    }
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (suggestions != null) {
+      data['suggestions'] = suggestions!.map((v) => v.toJson()).toList();
+    }
+    return data;
+  }
+}
+
+class Suggestion {
+  PlacePrediction? placePrediction;
+
+  Suggestion({this.placePrediction});
+
+  Suggestion.fromJson(Map<String, dynamic> json) {
+    placePrediction = json['placePrediction'] != null
+        ? PlacePrediction.fromJson(json['placePrediction'])
+        : null;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (placePrediction != null) {
+      data['placePrediction'] = placePrediction!.toJson();
+    }
+    return data;
+  }
+}
+
+class PlacePrediction {
+  String? place;
+  String? placeId;
+  TextWithMatches? text;
+  StructuredFormatV2? structuredFormat;
+  List<String>? types;
+
+  PlacePrediction({
+    this.place,
+    this.placeId,
+    this.text,
+    this.structuredFormat,
+    this.types,
+  });
+
+  PlacePrediction.fromJson(Map<String, dynamic> json) {
+    place = json['place'];
+    placeId = json['placeId'];
+    text = json['text'] != null ? TextWithMatches.fromJson(json['text']) : null;
+    structuredFormat = json['structuredFormat'] != null
+        ? StructuredFormatV2.fromJson(json['structuredFormat'])
+        : null;
+    types = json['types']?.cast<String>();
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['place'] = place;
+    data['placeId'] = placeId;
+    if (text != null) {
+      data['text'] = text!.toJson();
+    }
+    if (structuredFormat != null) {
+      data['structuredFormat'] = structuredFormat!.toJson();
+    }
+    data['types'] = types;
+    return data;
+  }
+}
+
+class TextWithMatches {
+  String? text;
+  List<TextMatch>? matches;
+
+  TextWithMatches({this.text, this.matches});
+
+  TextWithMatches.fromJson(Map<String, dynamic> json) {
+    text = json['text'];
+    if (json['matches'] != null) {
+      matches = [];
+      json['matches'].forEach((v) {
+        matches!.add(TextMatch.fromJson(v));
+      });
+    }
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['text'] = text;
+    if (matches != null) {
+      data['matches'] = matches!.map((v) => v.toJson()).toList();
+    }
+    return data;
+  }
+}
+
+class TextMatch {
+  int? endOffset;
+
+  TextMatch({this.endOffset});
+
+  TextMatch.fromJson(Map<String, dynamic> json) {
+    endOffset = json['endOffset'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['endOffset'] = endOffset;
+    return data;
+  }
+}
+
+class StructuredFormatV2 {
+  TextWithMatches? mainText;
+  TextWithMatches? secondaryText;
+
+  StructuredFormatV2({this.mainText, this.secondaryText});
+
+  StructuredFormatV2.fromJson(Map<String, dynamic> json) {
+    mainText = json['mainText'] != null
+        ? TextWithMatches.fromJson(json['mainText'])
+        : null;
+    secondaryText = json['secondaryText'] != null
+        ? TextWithMatches.fromJson(json['secondaryText'])
+        : null;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (mainText != null) {
+      data['mainText'] = mainText!.toJson();
+    }
+    if (secondaryText != null) {
+      data['secondaryText'] = secondaryText!.toJson();
+    }
+    return data;
+  }
+}

--- a/lib/model/prediction_adapter.dart
+++ b/lib/model/prediction_adapter.dart
@@ -1,0 +1,24 @@
+import 'new_prediction.dart';
+import 'prediction.dart';
+
+class PredictionAdapter {
+  static Prediction fromSuggestion(Suggestion suggestion) {
+    final placePrediction = suggestion.placePrediction;
+    if (placePrediction == null) {
+      return Prediction();
+    }
+
+    return Prediction(
+      description: placePrediction.text?.text,
+      id: null, 
+      placeId: placePrediction.placeId,
+      reference: null,
+      structuredFormatting:null,
+      terms: null,
+      types: placePrediction.types,
+      matchedSubstrings:null,
+      lat: null,
+      lng: null,
+    );
+  }
+}


### PR DESCRIPTION
This change resolves issues #72 、 #74 

## New Features 
- [Google Places API (v1)](https://developers.google.com/maps/documentation/places/web-service/op-overview) support  
- Add `useNewApi` flag to toggle between **legacy API** and **new API**  
- Default is `false` to avoid breaking changes for existing users  

## Details
- Implemented new endpoints for:
  - [Place Autocomplete](https://developers.google.com/maps/documentation/places/web-service/place-autocomplete)  
  - [Place Details](https://developers.google.com/maps/documentation/places/web-service/place-details)  
- Enhanced error handling (support `error.message` from v1 API)  
- Updated example and README with usage of `useNewApi`  

## Notes
- Legacy API remains fully supported