### PR TITLE
fix: Null check error when widget unmounts during debounce

### DIFF
--- a/lib/google_places_flutter.dart
+++ b/lib/google_places_flutter.dart
@@ -118,13 +118,13 @@ class _GooglePlaceAutoCompleteTextFieldState
                 style: widget.textStyle,
                 controller: widget.textEditingController,
                 focusNode: widget.focusNode ?? FocusNode(),
-                keyboardType: widget.keyboardType ?? TextInputType.streetAddress,
+                keyboardType:
+                    widget.keyboardType ?? TextInputType.streetAddress,
                 textInputAction: widget.textInputAction ?? TextInputAction.done,
                 onFieldSubmitted: (value) {
-                  if(widget.formSubmitCallback!=null){
+                  if (widget.formSubmitCallback != null) {
                     widget.formSubmitCallback!();
                   }
-
                 },
                 validator: (inputString) {
                   return widget.validator?.call(inputString, context);
@@ -231,11 +231,15 @@ class _GooglePlaceAutoCompleteTextFieldState
   }
 
   textChanged(String text) async {
+    if (!mounted) return;
+
     if (text.isNotEmpty) {
       getLocation(text);
     } else {
       alPredictions.clear();
-      this._overlayEntry!.remove();
+      if (_overlayEntry?.mounted ?? false) {
+        _overlayEntry!.remove();
+      }
     }
   }
 
@@ -268,7 +272,7 @@ class _GooglePlaceAutoCompleteTextFieldState
                             widget.itemClick!(selectedData);
 
                             if (widget.isLatLngRequired) {
-                             await getPlaceDetailsFromPlaceId(selectedData);
+                              await getPlaceDetailsFromPlaceId(selectedData);
                             }
                             removeOverlay();
                           }


### PR DESCRIPTION
## Problem

The widget crashes when `textChanged` is called after the widget has been disposed. This happens because the debounce stream can fire after navigation or widget removal.

### Crash log
```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value
    at _GooglePlaceAutoCompleteTextFieldState.textChanged(google_places_flutter.dart:238)
    at _MultiStreamController.addSync(dart:async)
    at _MultiControllerSink.add(forwarding_stream.dart:135)
    at _BackpressureStreamSink.resolveWindowEnd(backpressure.dart:214)
    at _BackpressureStreamSink.singleWindow.<fn>(backpressure.dart:155)
    at _StreamController.add(dart:async)
    at TimerStream._buildController.<fn>.<fn>(timer.dart:51)
```

## Solution

- Added `mounted` check at the start of `textChanged` to prevent execution after widget disposal
- Added null-safe check on `_overlayEntry` before calling `remove()`

## Changes
```dart
// Before
textChanged(String text) async {
  if (text.isNotEmpty) {
    getLocation(text);
  } else {
    alPredictions.clear();
    this._overlayEntry!.remove();
  }
}

// After
textChanged(String text) async {
  if (!mounted) return;

  if (text.isNotEmpty) {
    getLocation(text);
  } else {
    alPredictions.clear();
    if (_overlayEntry?.mounted ?? false) {
      _overlayEntry!.remove();
    }
  }
}
```